### PR TITLE
Add support for YottaDB environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .npmignore
+build
+builderror.log

--- a/binding.gyp
+++ b/binding.gyp
@@ -37,14 +37,15 @@
         'GTM_VERSION=63'
       ],
       'variables': {
-        'gtm_dist%': '$(gtm_dist)'
+        'gtm_dist%': '<!(if test "$ydb_dist" != "" ; then echo $ydb_dist; else echo $gtm_dist; fi)'
       },
       'include_dirs': [
         '<(gtm_dist)'
       ],
       'libraries': [
         '-L<(gtm_dist)',
-        '-lgtmshr'
+        '-lgtmshr',
+        '-lyottadb'
       ],
       'ldflags': [
         '-Wl,-rpath,<(gtm_dist),--enable-new-dtags'

--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -19,14 +19,14 @@
  */
 
 var exec = require('child_process').exec;
-var gtmDist = process.env.gtm_dist;
+var gtmDist = (process.env.ydb_dist ? process.env.ydb_dist : process.env.gtm_dist);
 
 if (gtmDist === undefined) {
     console.error(__filename + ': Error: Set the $gtm_dist environment variable to the YottaDB/GT.M root directory\n');
     process.exit(1);
 }
 
-var gtmRoutines = process.env.gtmroutines;
+var gtmRoutines = (process.env.ydb_routines ? process.env.ydb_routines : process.env.gtmroutines);
 
 if (gtmRoutines === undefined) {
     console.error(__filename + ': Error: Set the $gtmroutines environment variable to include v4wNode.m\n');

--- a/lib/preinstall.js
+++ b/lib/preinstall.js
@@ -19,7 +19,7 @@
  */
 
 var exec = require('child_process').exec;
-var gtmDist = process.env.gtm_dist;
+var gtmDist = (process.env.ydb_dist ? process.env.ydb_dist : process.env.gtm_dist);
 
 if (gtmDist === undefined) {
     console.error(__filename + ': Error: Set the $gtm_dist environment variable to the YottaDB/GT.M root directory\n');


### PR DESCRIPTION
Nodem only looked for gtm environment variables and if only YottaDB
environment variables were defined Nodem wouldn't compile. Add support
by checking "ydb_" prefixed variables before defaulting to "gtm" prefixed
variables. This ensures that "gtm" prefixed variables will always be the
default variables.

Also, add a .gitignore to prevent build artifacts from getting committed.